### PR TITLE
Use native file and directory pickers instead of the GTK ones

### DIFF
--- a/classes/gui/dialogs/directory/dirdlg_gtk.cpp
+++ b/classes/gui/dialogs/directory/dirdlg_gtk.cpp
@@ -17,18 +17,18 @@ const Error &S::GUI::Dialogs::DirSelection::ShowDialog()
 {
 	/* Create file chooser dialog.
 	 */
-	GtkWidget	*dialog = gtk_file_chooser_dialog_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-							      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-							      GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
-							      NULL);
+	GtkFileChooserNative	*dialog = gtk_file_chooser_native_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+							      "_Open", "_Cancel");
 
 	if (directory != NIL) gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), directory);
 
 	/* Run dialog and check result.
 	 */
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
+	if (gtk_native_dialog_run(GTK_NATIVE_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
 	{
-		char	*name = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+
+		GtkFileChooser *chooser = GTK_FILE_CHOOSER(dialog);
+		char	*name = gtk_file_chooser_get_filename(chooser);
 
 		directory.ImportFrom("UTF-8", name);
 
@@ -39,7 +39,7 @@ const Error &S::GUI::Dialogs::DirSelection::ShowDialog()
 		directory = NIL;
 	}
 
-	gtk_widget_destroy(dialog);
+	g_object_unref(dialog);
 
 	/* Wait for GTK to finish pending actions.
 	 */

--- a/classes/gui/dialogs/file/filedlg_gtk.cpp
+++ b/classes/gui/dialogs/file/filedlg_gtk.cpp
@@ -19,23 +19,19 @@ const Error &S::GUI::Dialogs::FileSelection::ShowDialog()
 {
 	/* Create file chooser dialog.
 	 */
-	GtkWidget	*dialog = NULL;
+	GtkFileChooserNative	*dialog = NULL;
 
 	if (mode == SFM_OPEN)
 	{
-		dialog = gtk_file_chooser_dialog_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_OPEN,
-						     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-						     GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
-						     NULL);
+		dialog = gtk_file_chooser_native_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_OPEN,
+						     "_Open", "_Cancel");
 
 		if (flags & SFD_ALLOWMULTISELECT) gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), True);
 	}
 	else if (mode == SFM_SAVE)
 	{
-		dialog = gtk_file_chooser_dialog_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_SAVE,
-						     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-						     GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-						     NULL);
+		dialog = gtk_file_chooser_native_new(caption, NULL, GTK_FILE_CHOOSER_ACTION_SAVE,
+						     "_Save", "_Cancel");
 
 		if (flags & SFD_CONFIRMOVERWRITE) gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), True);
 	}
@@ -73,7 +69,7 @@ const Error &S::GUI::Dialogs::FileSelection::ShowDialog()
 
 	/* Run dialog and check result.
 	 */
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
+	if (gtk_native_dialog_run(GTK_NATIVE_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
 	{
 		GSList	*list = gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(dialog));
 		GSList	*current = list;
@@ -106,7 +102,7 @@ const Error &S::GUI::Dialogs::FileSelection::ShowDialog()
 		error = Error();
 	}
 
-	gtk_widget_destroy(dialog);
+	g_object_unref(dialog);
 
 	/* Wait for GTK to finish pending actions.
 	 */


### PR DESCRIPTION
Changed the file and directory choosers to use the native versions via xdg-desktop-portal instead of the default GTK ones

Tested it with the current master commits on enzo1982/freac@48f26ca213787c05798d6e78dafa0113630cb96d and enzo1982/BoCA@a76c586f9e53f0fab8403d62fcbbfd1491bb1166 on KDE neon (Ubuntu 24.04.2 LTS) with Plasma 6.3.1 on Wayland.