### PR TITLE
Prefer Xft.dpi for fractional Linux DPI scaling

### DIFF
--- a/classes/backends/xlib/backendxlib.cpp
+++ b/classes/backends/xlib/backendxlib.cpp
@@ -377,3 +377,26 @@ S::String S::Backends::BackendXLib::QueryXfConf(const String &channel, const Str
 
 	return NIL;
 }
+
+S::String S::Backends::BackendXLib::QueryXftDPI()
+{
+	Display	*display = GetDisplay();
+
+	if (display == NIL) return NIL;
+
+	char	*resourceString = XResourceManagerString(display);
+
+	if (resourceString == NIL) return NIL;
+
+	String	 resources = resourceString;
+	Int	 pos	   = resources.Find("Xft.dpi:");
+
+	if (pos == -1) return NIL;
+
+	String	 value = resources.Tail(resources.Length() - pos - String("Xft.dpi:").Length());
+
+	value = value.Head(value.Find("\n") == -1 ? value.Length() : value.Find("\n"));
+	value = value.Trim();
+
+	return value;
+}

--- a/classes/graphics/backends/cairo/surfacecairo.cpp
+++ b/classes/graphics/backends/cairo/surfacecairo.cpp
@@ -221,6 +221,12 @@ S::Short S::GUI::SurfaceCairo::GetSurfaceDPI() const
 		if (ex_gdk_screen_get_monitor_scale_factor != NIL) scale = ex_gdk_screen_get_monitor_scale_factor(gdk_screen_get_default(), 0);
 		else						   scale = (Int64) Number::FromIntString(getenv("GDK_SCALE"));
 
+		/* Prefer the fractional Xft.dpi X resource if available.
+		 */
+		Float	 xftDPI = Backends::BackendXLib::QueryXftDPI().ToFloat();
+
+		if (xftDPI > 0) scale = xftDPI / dpi;
+
 		/* Alternatively, query the scale factor from the KDE configuration.
 		 */
 		if (scale <= 1.0) scale = Backends::BackendXLib::QueryKDESettings("KScreen", "ScaleFactor").ToFloat();

--- a/classes/graphics/backends/xlib/surfacexlib.cpp
+++ b/classes/graphics/backends/xlib/surfacexlib.cpp
@@ -193,7 +193,11 @@ S::Short S::GUI::SurfaceXLib::GetSurfaceDPI() const
 	/* Evaluate GDK_SCALE setting.
 	 */
 	Float	 dpi   = 96.0;
-	Int	 scale = (Int64) Number::FromIntString(getenv("GDK_SCALE"));
+	Float	 scale = (Int64) Number::FromIntString(getenv("GDK_SCALE"));
+
+	Float	 xftDPI = Backends::BackendXLib::QueryXftDPI().ToFloat();
+
+	if (xftDPI > 0) scale = xftDPI / dpi;
 
 	if (scale > 0) dpi *= scale;
 

--- a/include/smooth/backends/xlib/backendxlib.h
+++ b/include/smooth/backends/xlib/backendxlib.h
@@ -72,6 +72,7 @@ namespace smooth
 				static String		 QueryGSettings(const String &, const String &);
 				static String		 QueryKDESettings(const String &, const String &);
 				static String		 QueryXfConf(const String &, const String &);
+				static String		 QueryXftDPI();
 		};
 	};
 };


### PR DESCRIPTION
## Problem

`GetSurfaceDPI()` on Linux only ever derived an *integer* scale factor (via `gdk_screen_get_monitor_scale_factor` or the `GDK_SCALE` env var). On desktops using fractional scaling (e.g. 1.75x, common on KDE/GNOME HiDPI setups), this either rounds to the nearest integer (making the UI noticeably too large or too small) or fails entirely under Flatpak sandboxing, where GDK's monitor-scale detection can't see the compositor's scale at all - resulting in the UI rendering at 1x regardless of the actual display scale.

## Fix

Adds `BackendXLib::QueryXftDPI()`, which reads the `Xft.dpi` X resource via `XResourceManagerString()`. This is the desktop-independent mechanism used by GNOME, KDE and XFCE alike to communicate display DPI to legacy toolkits. It already supports fractional values, and - unlike the GDK monitor scale factor - remains available to sandboxed applications (e.g. Flatpak) that only have access to the X11 socket, since it requires no filesystem or GTK theme access.

This value is now preferred over the integer GDK-based detection in both the cairo and plain xlib surface backends.

## Testing

Verified visually on KDE Plasma (Wayland session, XWayland client) at 1.75x scale - the UI now renders at the correct scale instead of rounding to 2x.