### PR TITLE
Wrap SP_MOUSEOUT erase in StartPaint/EndPaint for consistency

### DIFF
--- a/classes/gui/widgets/hotspot/simplebutton.cpp
+++ b/classes/gui/widgets/hotspot/simplebutton.cpp
@@ -42,7 +42,9 @@ S::Int S::GUI::HotspotSimpleButton::Paint(Int message)
 
 			break;
 		case SP_MOUSEOUT:
+			surface->StartPaint(frame);
 			surface->Box(frame, GetBackgroundColor(), Rect::Outlined);
+			surface->EndPaint();
 
 			break;
 	}


### PR DESCRIPTION
The other three cases here (SP_MOUSEIN/SP_MOUSEUP/SP_MOUSEDOWN) draw via Frame(), which wraps itself in StartPaint()/EndPaint(). This case draws via Box() directly, which doesn't self wrap and behaves differently depending on timing when called outside an active paint scope (see SurfaceCairo::Box(), direct to window vs. cached). Wrapping this call the same way keeps all four states going through the same rendering path.