### PR TITLE
Fix garbled thumbnails for grayscale/CMYK JPEG cover art

### DIFF
--- a/classes/graphics/imageloader/jpeg.cpp
+++ b/classes/graphics/imageloader/jpeg.cpp
@@ -103,6 +103,11 @@ const S::GUI::Bitmap &S::GUI::ImageLoaderJPEG::Load()
 	 * See libjpeg.doc for more info.
 	 */
 
+	/* Force RGB output regardless of the source color space (e.g. grayscale
+	 * or CMYK), since the scanline copy loop below assumes 3 components.
+	 */
+	cinfo.out_color_space = JCS_RGB;
+
 	/* Start decompressor
 	 */
 	jpeg_start_decompress(&cinfo);


### PR DESCRIPTION
ImageLoaderJPEG::Load() copies each decoded scanline assuming 3 bytes
per pixel, but never forces libjpeg's output color space. A grayscale
(1 component) or CMYK (4 component) source JPEG then produces a row
buffer shorter or longer than the loop assumes, so most of each row
gets read out of bounds. Embedded cover art using either format shows
up as partially garbled noise.

Fix: set cinfo.out_color_space = JCS_RGB before starting decompression,
so libjpeg always hands back a 3-component RGB buffer regardless of
the source's native color space.